### PR TITLE
Attempt to fix broken Github Actions CI on Linux

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -11,11 +11,22 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        cxx: [g++-9, g++-10, g++-11, clang++-10, clang++-12] # see below for clang-11
+        cxx: [g++-9, g++-10, clang++-10, clang++-12] # see below for clang-11
         build_type: [Debug, Release]
         std: [17, 20]
         os: [ubuntu-20.04]
         include:
+          # Test GCC 11 on Ubuntu 18.04
+          - cxx: g++-11
+            std: 17
+            build_type: Debug
+            os: ubuntu-18.04
+            install: sudo apt install g++-11
+          - cxx: g++-11
+            std: 20
+            build_type: Debug
+            os: ubuntu-18.04
+            install: sudo apt install g++-11
           # Test Clang 9 on Ubuntu 18.04
           - cxx: clang++-9
             std: 17

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -23,8 +23,18 @@ jobs:
             os: ubuntu-18.04
             install: sudo apt install g++-11
           - cxx: g++-11
+            std: 17
+            build_type: Release
+            os: ubuntu-18.04
+            install: sudo apt install g++-11
+          - cxx: g++-11
             std: 20
             build_type: Debug
+            os: ubuntu-18.04
+            install: sudo apt install g++-11
+          - cxx: g++-11
+            std: 20
+            build_type: Release
             os: ubuntu-18.04
             install: sudo apt install g++-11
           # Test Clang 9 on Ubuntu 18.04


### PR DESCRIPTION
g++-11 appears to have disappeared from Github Actions' default configuration.
As a first try at fixing it, we'll attempt to manually install it with apt-get,
as we do with the various Clangs