### PR TITLE
Support C++20 coroutines as well as TS coroutines

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -42,12 +42,6 @@ jobs:
             std: 17
             build_type: Debug
             os: ubuntu-18.04
-          - cxx: clang++-9
-            std: 17
-            build_type: Debug
-            os: ubuntu-18.04
-            cxx_flags: -stdlib=libc++
-            install: sudo apt install libc++-9-dev libc++abi-9-dev
           # Test Clang 11 with both libstdc++ and libc++
           - cxx: clang++-11
             std: 17

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -102,7 +102,7 @@ jobs:
       working-directory: ${{runner.workspace}}/build
       env:
         CXX: ${{matrix.cxx}}
-        CXXFLAGS: ${{matrix.cxxflags}}
+        CXXFLAGS: ${{matrix.cxx_flags}}
       run: |
         cmake -DCMAKE_BUILD_TYPE=${{matrix.build_type}}  \
               -DCMAKE_CXX_STANDARD=${{matrix.std}}  \

--- a/example/CMakeLists.txt
+++ b/example/CMakeLists.txt
@@ -7,9 +7,6 @@ function(add_example NAME)
         target_compile_options(example_${NAME} PRIVATE -fcoroutines-ts)
     endif()
 
-    if (MSVC)
-        target_compile_options(example_${NAME} PRIVATE /await)
-    endif()
 endfunction()
 
 add_example(custom_adaptor)

--- a/include/flow/core/macros.hpp
+++ b/include/flow/core/macros.hpp
@@ -20,15 +20,17 @@
 #define FLOW_NO_UNIQUE_ADDRESS
 #endif
 
-#if defined(__cpp_coroutines)
-#  if defined(__has_include) // If we can, check for <experimental/coroutine>
-#    if __has_include(<experimental/coroutine>)
+#if defined(__cpp_coroutines) || defined(__cpp_impl_coroutine)
+#  if defined(__has_include) // If we can, check for <coroutine> or <experimental/coroutine>
+#    if __has_include(<coroutine>)
 #      define FLOW_HAVE_COROUTINES
-#    endif // __cpp_coroutines
-#  else // can't check for it, let's hope for the best
-#    define FLOW_HAVE_COROUTINES
+#      define FLOW_HAVE_CPP20_COROUTINES
+#    elif __has_include(<experimental/coroutine>)
+#      define FLOW_HAVE_COROUTINES
+#      define FLOW_HAVE_TS_COROUTINES
+#    endif // __has_include(<coroutine>)
 #  endif // __has_include
-#endif // __cpp_coroutines
+#endif // __cpp_impl_coroutine
 
 #define FLOW_FWD(x) (static_cast<decltype(x)&&>(x))
 

--- a/include/flow/core/macros.hpp
+++ b/include/flow/core/macros.hpp
@@ -20,17 +20,21 @@
 #define FLOW_NO_UNIQUE_ADDRESS
 #endif
 
-#if defined(__cpp_coroutines) || defined(__cpp_impl_coroutine)
-#  if defined(__has_include) // If we can, check for <coroutine> or <experimental/coroutine>
+#if defined(__cpp_impl_coroutine)  // We have language support for C++20 coroutines
+#  if defined(__has_include)
 #    if __has_include(<coroutine>)
 #      define FLOW_HAVE_COROUTINES
 #      define FLOW_HAVE_CPP20_COROUTINES
-#    elif __has_include(<experimental/coroutine>)
-#      define FLOW_HAVE_COROUTINES
-#      define FLOW_HAVE_TS_COROUTINES
-#    endif // __has_include(<coroutine>)
+#    endif  // __has_include(<coroutine>)
 #  endif // __has_include
-#endif // __cpp_impl_coroutine
+#elif defined(__cpp_coroutines) // We have language support for TS coroutines
+#  if defined(__has_include)
+#    if __has_include(<experimental/coroutine>)
+#        define FLOW_HAVE_COROUTINES
+#        define FLOW_HAVE_TS_COROUTINES
+#    endif // __has_include(<experimental/coroutine>)
+#  endif // __has_include
+#endif
 
 #define FLOW_FWD(x) (static_cast<decltype(x)&&>(x))
 

--- a/include/flow/source/async.hpp
+++ b/include/flow/source/async.hpp
@@ -12,16 +12,30 @@
 
 #include <flow/core/flow_base.hpp>
 
+#ifdef FLOW_HAVE_CPP20_COROUTINES
+#include <coroutine>
+#else
 #include <experimental/coroutine>
+#endif
 
 namespace flow {
+
+namespace detail {
+
+#ifdef FLOW_HAVE_CPP20_COROUTINES
+namespace coro_ns = std;
+#else
+namespace coro_ns = std::experimental;
+#endif
+
+}
 
 template <typename T>
 struct async : flow_base<async<T>>
 {
     struct promise_type;
 
-    using handle_type = std::experimental::coroutine_handle<promise_type>;
+    using handle_type = detail::coro_ns::coroutine_handle<promise_type>;
 
     struct promise_type {
     private:
@@ -29,23 +43,23 @@ struct async : flow_base<async<T>>
 
     public:
         auto initial_suspend() {
-            return std::experimental::suspend_always{};
+            return detail::coro_ns::suspend_always{};
         };
 
         auto final_suspend() noexcept {
-            return std::experimental::suspend_always{};
+            return detail::coro_ns::suspend_always{};
         }
 
         auto yield_value(std::remove_reference_t<T>& val)
         {
             value = maybe<T>(val);
-            return std::experimental::suspend_always{};
+            return detail::coro_ns::suspend_always{};
         }
 
         auto yield_value(remove_cvref_t<T>&& val)
         {
             value = maybe<T>(std::move(val));
-            return std::experimental::suspend_always{};
+            return detail::coro_ns::suspend_always{};
         }
 
         auto extract_value() -> maybe<T>
@@ -67,7 +81,7 @@ struct async : flow_base<async<T>>
 
         auto return_void()
         {
-            return std::experimental::suspend_never{};
+            return detail::coro_ns::suspend_never{};
         }
     };
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -79,9 +79,5 @@ if (CMAKE_CXX_COMPILER_ID MATCHES "Clang")
         -ftemplate-backtrace-limit=0)
 endif()
 
-if (MSVC)
-    target_compile_options(test-libflow PRIVATE /await)
-endif()
-
 include(Catch)
 catch_discover_tests(test-libflow)


### PR DESCRIPTION
Recent GCCs have coroutines support in C++20 mode, or in earlier modes
using the -fcoroutines flag. The language feature test macro is __cpp_impl_coroutine,
and the library support is in header <coroutine> and namespace std.

Clang on the other hand, even the latest upstream version I have, doens't support
C++20 coroutines. It does have TS coroutines though with the -fcoroutines-ts flag,
which gets set by our CMake config. The language feature test macro is __cpp_coroutines,
and the library support is in header <experimental/coroutine> and namespace
std::experimental.

With MSVC... who knows

Fortunately for us, the bits we need didn't change between the TS and C++20, so we
can first check for <coroutine> and if so, use C++20 coroutines; otherwise, we check
for <experimental/coroutine> and use TS coroutines.

I don't know whether this will work on MSVC, because I think only very recent versions
support __has_include.